### PR TITLE
Resource plugin

### DIFF
--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -9,6 +9,7 @@ MRuby::Gem::Specification.new('itamae') do |spec|
   spec.bins    = ['itamae']
 
   spec.add_dependency 'mruby-dir',        mgem: 'mruby-dir'
+  spec.add_dependency 'mruby-dir-glob',   mgem: 'mruby-dir-glob'
   spec.add_dependency 'mruby-enumerator', core: 'mruby-enumerator'
   spec.add_dependency 'mruby-env',        mgem: 'mruby-env'
   spec.add_dependency 'mruby-erb',      github: 'k0kubun/mruby-erb'

--- a/mrblib/itamae/cli/local.rb
+++ b/mrblib/itamae/cli/local.rb
@@ -22,6 +22,8 @@ module Itamae
         Itamae.logger = Logger.new(@options[:log_level])
         Itamae.logger.info 'Starting Itamae...'
 
+        Plugin.load_plugins
+
         runner = RecipeRunner.new(
           node_json: @options[:node_json],
           dry_run:   @options[:dry_run],

--- a/mrblib/itamae/plugin.rb
+++ b/mrblib/itamae/plugin.rb
@@ -1,5 +1,15 @@
 module Itamae
   module Plugin
+    # Load plugins/*/mrblib/**/*.rb before running recipes.
+    # Put a plugin repository under plugins as git submodule or just copy it.
+    def self.load_plugins
+      if File.directory?('plugins')
+        Dir.glob('plugins/*/mrblib/**/*.rb').sort.each do |source|
+          eval File.read(source)
+        end
+      end
+    end
+
     # Define resource plugins under `Itamae::Plugin::Resource::`.
     module Resource
       def self.resource_plugin?(klass)

--- a/mrblib/itamae/plugin.rb
+++ b/mrblib/itamae/plugin.rb
@@ -1,0 +1,17 @@
+module Itamae
+  module Plugin
+    # Define resource plugins under `Itamae::Plugin::Resource::`.
+    module Resource
+      def self.resource_plugin?(klass)
+        klass.to_s =~ /\AItamae::Plugin::Resource::[a-zA-Z\d]+\z/
+      end
+    end
+
+    # Define resource executor plugins under `Itamae::Plugin::ResourceExecutor::`.
+    module ResourceExecutor
+      def self.find(klass)
+        const_get(klass.to_s.sub(/\AItamae::Plugin::Resource::/, ''))
+      end
+    end
+  end
+end

--- a/mrblib/itamae/recipe_context.rb
+++ b/mrblib/itamae/recipe_context.rb
@@ -2,6 +2,13 @@ module Itamae
   class RecipeContext
     NotFoundError = Class.new(StandardError)
 
+    def self.register_resource(klass)
+      method_name = klass.to_s.split('::').last.gsub(/([a-z\d])([A-Z])/,'\1_\2').downcase
+      define_method(method_name) do |name, &block|
+        @recipe.children << klass.new(name, @recipe, @variables, &block)
+      end
+    end
+
     def initialize(recipe, variables = {})
       @recipe = recipe
       @variables = variables

--- a/mrblib/itamae/resource/base.rb
+++ b/mrblib/itamae/resource/base.rb
@@ -10,6 +10,10 @@ module Itamae
 
         def inherited(subclass)
           subclass.defined_attributes = self.defined_attributes.dup
+
+          if Plugin::Resource.resource_plugin?(subclass)
+            RecipeContext.register_resource(subclass)
+          end
         end
 
         def define_attribute(name, options = {})

--- a/mrblib/itamae/resource_executor.rb
+++ b/mrblib/itamae/resource_executor.rb
@@ -13,6 +13,8 @@ module Itamae
         class_name = resource_class.to_s
         if class_name.start_with?('Itamae::Resource::')
           const_get(class_name.sub(/\AItamae::Resource::/, ''))
+        elsif Plugin::Resource.resource_plugin?(class_name)
+          Plugin::ResourceExecutor.find(resource_class)
         else
           raise NotFoundError, "executor not found for '#{class_name}'"
         end


### PR DESCRIPTION
- Resource plugin must be `Itamae::Plugin::Resource::*` and inherit `Itamae::Resource::Base`
  - Its executor must be `Itamae::Plugin::ResourceExecutor::*`
- mrbgem repositories under `plugins/` are automatically loaded
  - Add them as git submodule or copy them
  - They should have code under `mrblib/`
- Example
  - Simple case: https://github.com/k0kubun/itamae-plugin-resource-cask/pull/4
  - Concept for complex case: https://github.com/k0kubun/itamae-plugin-resource-portage/pull/1